### PR TITLE
Fix tests that rely on the to_graphql_error hook

### DIFF
--- a/apollo-router/src/axum_factory/tests.rs
+++ b/apollo-router/src/axum_factory/tests.rs
@@ -89,6 +89,7 @@ use crate::uplink::license_enforcement::LicenseState;
 use crate::ApolloRouterError;
 use crate::Configuration;
 use crate::Context;
+use crate::error::setup_test_custom_errors;
 use crate::ListenAddr;
 use crate::TestHarness;
 
@@ -971,6 +972,7 @@ async fn response_with_custom_endpoint_wildcard() -> Result<(), ApolloRouterErro
 
 #[tokio::test]
 async fn response_failure() -> Result<(), ApolloRouterError> {
+    setup_test_custom_errors();
     let router_service = router::service::from_supergraph_mock_callback(move |req| {
         let example_response = crate::error::FetchError::SubrequestHttpError {
             status_code: Some(200),
@@ -2287,6 +2289,7 @@ async fn test_supergraph_and_health_check_same_port_different_listener() {
 
 #[tokio::test]
 async fn test_supergraph_timeout() {
+    setup_test_custom_errors();
     let config = serde_json::json!({
         "supergraph": {
             "defer_support": false,

--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -128,7 +128,74 @@ pub unsafe fn set_to_graphql_error(
         .unwrap();
 }
 
+#[cfg(test)]
+static CUSTOM_ERRORS_SETUP: OnceLock<bool> = OnceLock::new();
+
+#[cfg(test)]
+pub(crate) fn setup_test_custom_errors() {
+    CUSTOM_ERRORS_SETUP.get_or_init(|| {
+        setup_custom_router_errors();
+        true
+    });
+}
+
+#[cfg(test)]
+pub fn setup_custom_router_errors() {
+    unsafe {
+        set_to_graphql_error(FetchError::to_graphql_error_for_tests);
+        set_into_graphql_errors(RouterError::into_graphql_errors_for_tests)
+    }
+}
+
 impl FetchError {
+    #[cfg(test)]
+    /// Convert the fetch error to a GraphQL error.
+    pub(crate) fn to_graphql_error_for_tests(&self, path: Option<Path>) -> Error {
+        let mut value: Value = serde_json_bytes::to_value(self).unwrap_or_default();
+        if let Some(extensions) = value.as_object_mut() {
+            extensions
+                .entry("code")
+                .or_insert_with(|| self.extension_code().into());
+            // Following these specs https://www.apollographql.com/docs/apollo-server/data/errors/#including-custom-error-details
+            match self {
+                FetchError::SubrequestHttpError {
+                    service,
+                    status_code,
+                    ..
+                } => {
+                    extensions
+                        .entry("service")
+                        .or_insert_with(|| service.clone().into());
+                    extensions.remove("status_code");
+                    if let Some(status_code) = status_code {
+                        extensions
+                            .insert("http", serde_json_bytes::json!({ "status": status_code }));
+                    }
+                }
+                FetchError::SubrequestMalformedResponse { service, .. }
+                | FetchError::SubrequestUnexpectedPatchResponse { service }
+                | FetchError::SubrequestWsError { service, .. } => {
+                    extensions
+                        .entry("service")
+                        .or_insert_with(|| service.clone().into());
+                }
+                FetchError::ValidationInvalidTypeVariable { name } => {
+                    extensions
+                        .entry("name")
+                        .or_insert_with(|| name.clone().into());
+                }
+                _ => (),
+            }
+        }
+
+        Error {
+            message: self.to_string(),
+            locations: Default::default(),
+            path,
+            extensions: value.as_object().unwrap().to_owned(),
+        }
+    }
+
     /// Convert the fetch error to a GraphQL error.
     pub(crate) fn to_graphql_error(&self, path: Option<Path>) -> Error {
         let callback = unsafe {
@@ -205,6 +272,7 @@ pub unsafe fn set_into_graphql_errors(
 }
 
 impl IntoGraphQLErrors for RouterError {
+
     fn into_graphql_errors(self) -> Result<Vec<Error>, Self> {
         let callback = unsafe {
             INTO_GRAPHQL_ERRORS
@@ -212,6 +280,17 @@ impl IntoGraphQLErrors for RouterError {
                 .expect("into_graphql_errors was not set")
         };
         callback(self)
+    }
+}
+
+impl RouterError {
+    #[cfg(test)]
+    fn into_graphql_errors_for_tests(self) -> Result<Vec<Error>, Self> {
+        match self {
+            RouterError::CacheResolver(e) => e.into_graphql_errors().map_err(|e| RouterError::CacheResolver(e)),
+            RouterError::QueryPlanner(e) => e.into_graphql_errors().map_err(|e| RouterError::QueryPlanner(e)),
+            RouterError::Planner(e) => e.into_graphql_errors().map_err(|e| RouterError::Planner(e)),
+        }
     }
 }
 

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -1267,6 +1267,7 @@ mod tests {
     use crate::protocols::websocket::WebSocketProtocol;
     use crate::query_planner::fetch::OperationKind;
     use crate::Context;
+    use crate::error::setup_test_custom_errors;
 
     // starts a local server emulating a subgraph returning status code 400
     async fn emulate_subgraph_bad_request(listener: TcpListener) {
@@ -2043,6 +2044,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_subgraph_service_invalid_response() {
+        setup_test_custom_errors();
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let socket_addr = listener.local_addr().unwrap();
         tokio::task::spawn(emulate_subgraph_ok_status_invalid_response(listener));
@@ -2123,6 +2125,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_subgraph_invalid_status_invalid_response_application_graphql() {
+        setup_test_custom_errors();
+
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let socket_addr = listener.local_addr().unwrap();
         tokio::task::spawn(
@@ -2263,6 +2267,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_bad_status_code_should_not_fail() {
+        setup_test_custom_errors();
+
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let socket_addr = listener.local_addr().unwrap();
         tokio::task::spawn(emulate_subgraph_bad_request(listener));
@@ -2304,6 +2310,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_bad_content_type() {
+        setup_test_custom_errors();
+
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let socket_addr = listener.local_addr().unwrap();
         tokio::task::spawn(emulate_subgraph_bad_response_format(listener));
@@ -2390,6 +2398,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_unauthorized() {
+        setup_test_custom_errors();
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let socket_addr = listener.local_addr().unwrap();
         tokio::task::spawn(emulate_subgraph_unauthorized(listener));

--- a/apollo-router/src/services/supergraph/tests.rs
+++ b/apollo-router/src/services/supergraph/tests.rs
@@ -15,6 +15,7 @@ use crate::spec::Schema;
 use crate::test_harness::MockedSubgraphs;
 use crate::Configuration;
 use crate::Context;
+use crate::error::setup_test_custom_errors;
 use crate::Notify;
 use crate::TestHarness;
 
@@ -1324,6 +1325,8 @@ async fn root_typename_with_defer_in_defer() {
 
 #[tokio::test]
 async fn query_reconstruction() {
+    setup_test_custom_errors();
+
     let schema = r#"schema
     @link(url: "https://specs.apollo.dev/link/v1.0")
     @link(url: "https://specs.apollo.dev/join/v0.2", for: EXECUTION)
@@ -3032,6 +3035,7 @@ async fn multiple_interface_types() {
 
 #[tokio::test]
 async fn id_scalar_can_overflow_i32() {
+    setup_test_custom_errors();
     // Hack to let the first subgraph fetch contain an ID variable:
     // ```
     // type Query {

--- a/apollo-router/src/spec/query/tests.rs
+++ b/apollo-router/src/spec/query/tests.rs
@@ -2,6 +2,7 @@ use apollo_compiler::Parser;
 use insta::assert_json_snapshot;
 use serde_json_bytes::json;
 use test_log::test;
+use crate::error::setup_test_custom_errors;
 
 use super::*;
 use crate::json_ext::ValueExt;
@@ -1437,6 +1438,7 @@ macro_rules! assert_validation_error {
 
 #[test]
 fn variable_validation() {
+    setup_test_custom_errors();
     let schema = r#"
         type Query {
             int(a: Int): String


### PR DESCRIPTION
13 tests were failing due to the hook not being initialized.