### PR TITLE
Add missing error hook for query planning errors

### DIFF
--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -415,10 +415,10 @@ static mut INTO_GRAPHQL_ERRORS_PLANNER: OnceLock<
     Box<dyn Fn(QueryPlannerError) -> Result<Vec<Error>, QueryPlannerError> + 'static>,
 > = OnceLock::new();
 pub unsafe fn set_into_graphql_errors_planner(
-    into_graphql_errors: impl Fn(QueryPlannerError) -> Result<Vec<Error>, QueryPlannerError> + 'static,
+    into_graphql_errors_planner: impl Fn(QueryPlannerError) -> Result<Vec<Error>, QueryPlannerError> + 'static,
 ) {
     crate::error::INTO_GRAPHQL_ERRORS_PLANNER
-        .set(Box::new(into_graphql_errors))
+        .set(Box::new(into_graphql_errors_planner))
         .map_err(|_| "into_graphql_errors_planner was already set")
         .unwrap();
 }

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -79,6 +79,7 @@ pub mod test_harness;
 pub mod tracer;
 mod uplink;
 
+pub use error::set_into_graphql_errors_planner;
 pub use error::set_into_graphql_errors;
 pub use error::set_to_graphql_error;
 pub use error::CacheResolverError;


### PR DESCRIPTION
This PR adds an additional hook function `set_into_graphql_errors_planner` to be used to map all query planning errors. 