### PR TITLE
Make QueryPlan.formatted_query_plan pub

### DIFF
--- a/apollo-router/src/query_planner/plan.rs
+++ b/apollo-router/src/query_planner/plan.rs
@@ -36,7 +36,7 @@ pub struct QueryPlan {
     pub(crate) usage_reporting: Arc<UsageReporting>,
     pub(crate) root: PlanNode,
     /// String representation of the query plan (not a json representation)
-    pub(crate) formatted_query_plan: Option<String>,
+    pub formatted_query_plan: Option<String>,
     pub(crate) query: Arc<Query>,
 }
 


### PR DESCRIPTION
Make QueryPlan.formatted_query_plan pub, this is so we can expose the query plan in our own plugin.